### PR TITLE
Remove @transform for string

### DIFF
--- a/src/Context/BaseContext.php
+++ b/src/Context/BaseContext.php
@@ -15,19 +15,6 @@ abstract class BaseContext extends RawMinkContext implements TranslatableContext
         return glob(__DIR__ . '/../../i18n/*.xliff');
     }
 
-    /**
-     * en
-     * @transform /^(0|[1-9]\d*)(?:st|nd|rd|th)?$/
-     *
-     * fr
-     * @transform /^(0|[1-9]\d*)(?:ier|er|e|ème)?$/
-     *
-     * pt
-     * @transform /^(0|[1-9]\d*)º?$/
-     *
-     * ru
-     * @transform /^(0|[1-9]\d*)(?:ой|ий|ый|ей|й)?$/
-     */
     public function castToInt($count)
     {
         if (intval($count) < PHP_INT_MAX) {


### PR DESCRIPTION
Remove @transform for string to avoid translating 1st to 1, 2nd to 2, ...
It's a breaking change on behat test and don't know why it has been accepted in behatch/contexts in the first place

| Q             | A
| ------------- | ---
| Branch?       | main (current)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT