### PR TITLE
Allow symfony/http-foundation ^6.0 instead of 6.0 to support symfony 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "friends-of-behat/mink-extension": "^2.3.1",
         "justinrainbow/json-schema": "^5.0",
         "symfony/property-access": "^2.3|^3.0|^4.0|^5.0|^6.0",
-        "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0|6.0",
+        "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0|^6.0",
         "symfony/dom-crawler": "^2.4|^3.0|^4.0|^5.0|^6.0"
     },
 


### PR DESCRIPTION
It should be ```symfony/http-foundation ^6.0``` instead of ```6.0```, am I correct?

Otherwise I am currently not able to use it with a symfony 6 project when restricting to symfony 6.1.* in composer.json.
See image below:
![image](https://user-images.githubusercontent.com/1651297/172308530-a3504347-5a7a-42f0-8d3d-fccef5d4cb5d.png)

When I restrict symfony to 6.0.* in composer.json then I can use soyuka contexts.

