### PR TITLE
[TableContext] fix integer value for text assertion

### DIFF
--- a/src/Context/TableContext.php
+++ b/src/Context/TableContext.php
@@ -13,7 +13,7 @@ class TableContext extends BaseContext
      *
      * @Then the columns schema of the :table table should match:
      */
-    public function theColumnsSchemaShouldMatch($table, TableNode $text): void
+    public function theColumnsSchemaShouldMatch(string $table, TableNode $text): void
     {
         $columnsSelector = "$table thead tr th";
         $columns = $this->getSession()->getPage()->findAll('css', $columnsSelector);
@@ -28,9 +28,9 @@ class TableContext extends BaseContext
     /**
      * Checks that the specified table contains the given number of columns.
      *
-     * @Then(I)should see :count column(s) in the :table table
+     * @Then (I )should see :count column(s) in the :table table
      */
-    public function iShouldSeeColumnsInTheTable($count, $table): void
+    public function iShouldSeeColumnsInTheTable(int $count, string $table): void
     {
         $columnsSelector = "$table thead tr th";
         $columns = $this->getSession()->getPage()->findAll('css', $columnsSelector);
@@ -41,9 +41,9 @@ class TableContext extends BaseContext
     /**
      * Checks that the specified table contains the specified number of rows in its body.
      *
-     * @Then(I)should see :count rows in the :index :table table
+     * @Then (I )should see :count rows in the :index :table table
      */
-    public function iShouldSeeRowsInTheNthTable($count, $index, $table): void
+    public function iShouldSeeRowsInTheNthTable(int $count, int $index, string $table): void
     {
         $actual = $this->countElements('tbody tr', $index, $table);
         $this->assertEquals($count, $actual);
@@ -52,9 +52,9 @@ class TableContext extends BaseContext
     /**
      * Checks that the specified table contains the specified number of rows in its body.
      *
-     * @Then(I)should see :count row(s) in the :table table
+     * @Then (I )should see :count row(s) in the :table table
      */
-    public function iShouldSeeRowsInTheTable($count, $table): void
+    public function iShouldSeeRowsInTheTable(int $count, string $table): void
     {
         $this->iShouldSeeRowsInTheNthTable($count, 1, $table);
     }
@@ -64,7 +64,7 @@ class TableContext extends BaseContext
      *
      * @Then the data in the :index row of the :table table should match:
      */
-    public function theDataOfTheRowShouldMatch($index, $table, TableNode $text): void
+    public function theDataOfTheRowShouldMatch(int $index, string $table, TableNode $text): void
     {
         $rowsSelector = "$table tbody tr";
         $rows = $this->getSession()->getPage()->findAll('css', $rowsSelector);
@@ -92,7 +92,7 @@ class TableContext extends BaseContext
      *
      * @Then the :colIndex column of the :rowIndex row in the :table table should contain :text
      */
-    public function theStColumnOfTheStRowInTheTableShouldContain($colIndex, $rowIndex, $table, $text): void
+    public function theStColumnOfTheStRowInTheTableShouldContain(int $colIndex, int $rowIndex, string $table, string $text): void
     {
         $rowSelector = "$table tbody tr";
         $rows = $this->getSession()->getPage()->findAll('css', $rowSelector);

--- a/tests/features/table.feature
+++ b/tests/features/table.feature
@@ -7,12 +7,13 @@ Feature: Browser Feature
     Scenario: Testing columns
         Given I am on "/table/index.html"
 
-        Then I should see 2 columns in the "table" table
+        Then I should see 3 columns in the "table" table
 
         And the columns schema of the "table" table should match:
             | columns |
             | Lorem   |
             | Ipsum   |
+            | Integer |
 
     Scenario: Testing rows
         Given I am on "/table/index.html"
@@ -46,3 +47,4 @@ Feature: Browser Feature
         Given I am on "/table/index.html"
         Then the 1st column of the 1st row in the "table" table should contain "Lorem"
         And the 2nd column of the 1st row in the "table" table should contain "Ipsum"
+        And the 3rd column of the 1st row in the "table" table should contain "42"

--- a/tests/fixtures/www/table/index.html
+++ b/tests/fixtures/www/table/index.html
@@ -5,21 +5,24 @@ You are about to test table.
     <tr>
       <th class="foo bar">Lorem</th>
       <th>Ipsum</th>
+      <th>Integer</th>
     </tr>
   </thead>
   <tfoot>
     <tr>
-      <td colspan="2">Lorem ipsum dolor sit amet</td>
+      <td colspan="3">Lorem ipsum dolor sit amet</td>
     </tr>
   </tfoot>
   <tbody>
     <tr>
       <td>Lorem</td>
       <td>Ipsum</td>
+      <td>42</td>
     </tr>
     <tr>
       <td>Dolor</td>
       <td>Sit</td>
+      <td>24</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

This PR fixes `@Then the :colIndex column of the :rowIndex row in the :table table should contain :text` when its content is an integer. 