### PR TITLE
Fix/php cs fixer break contexts

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -111,6 +111,7 @@ return (new PhpCsFixer\Config())
                 'property',
             ],
         ],
+        'declare_strict_types' => false,
     ])
     ->setFinder($finder);
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -19,6 +19,11 @@ $finder = PhpCsFixer\Finder::create()
         'tests/Fixtures/app/console',
     ]);
 
+$defaultIgnoreTags = (new PhpCsFixer\Fixer\DoctrineAnnotation\DoctrineAnnotationSpacesFixer())
+    ->getConfigurationDefinition()
+    ->resolve([])['ignored_tags'] ?? []
+;
+
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
@@ -39,6 +44,12 @@ return (new PhpCsFixer\Config())
         'doctrine_annotation_spaces' => [
             'after_array_assignments_equals' => false,
             'before_array_assignments_equals' => false,
+            'ignored_tags' => array_merge($defaultIgnoreTags, [
+                // Behat step tags
+                'Given',
+                'When',
+                'Then',
+            ]),
         ],
         'explicit_indirect_variable' => true,
         'fully_qualified_strict_types' => true,

--- a/src/Asserter.php
+++ b/src/Asserter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch;
 
 use Behat\Mink\Exception\ExpectationException;

--- a/src/Context/BaseContext.php
+++ b/src/Context/BaseContext.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Context;
 
 use Behat\Behat\Context\TranslatableContext;

--- a/src/Context/BrowserContext.php
+++ b/src/Context/BrowserContext.php
@@ -33,7 +33,7 @@ class BrowserContext extends BaseContext
     /**
      * @BeforeScenario
      *
-     * @When(I)start timing now
+     * @When (I )start timing now
      */
     public function startTimer(): void
     {
@@ -53,7 +53,7 @@ class BrowserContext extends BaseContext
     /**
      * Open url with various parameters.
      *
-     * @Given(I)am on url composed by:
+     * @Given (I )am on url composed by:
      */
     public function iAmOnUrlComposedBy(TableNode $tableNode)
     {
@@ -69,7 +69,7 @@ class BrowserContext extends BaseContext
     /**
      * Clicks on the nth CSS element.
      *
-     * @When(I)click on the :index :element element
+     * @When (I )click on the :index :element element
      */
     public function iClickOnTheNthElement($index, $element): void
     {
@@ -80,7 +80,7 @@ class BrowserContext extends BaseContext
     /**
      * Click on the nth specified link.
      *
-     * @When(I)follow the :index :link link
+     * @When (I )follow the :index :link link
      */
     public function iFollowTheNthLink($index, $link): void
     {
@@ -91,7 +91,7 @@ class BrowserContext extends BaseContext
     /**
      * Presses the nth specified button.
      *
-     * @When(I)press the :index :button button
+     * @When (I )press the :index :button button
      */
     public function pressTheNthButton($index, $button): void
     {
@@ -102,7 +102,7 @@ class BrowserContext extends BaseContext
     /**
      * Fills in form field with current date.
      *
-     * @When(I)fill in :field with the current date
+     * @When (I )fill in :field with the current date
      */
     public function iFillInWithTheCurrentDate($field)
     {
@@ -112,7 +112,7 @@ class BrowserContext extends BaseContext
     /**
      * Fills in form field with current date and strtotime modifier.
      *
-     * @When(I)fill in :field with the current date and modifier :modifier
+     * @When (I )fill in :field with the current date and modifier :modifier
      */
     public function iFillInWithTheCurrentDateAndModifier($field, $modifier)
     {
@@ -123,7 +123,7 @@ class BrowserContext extends BaseContext
     /**
      * Mouse over a CSS element.
      *
-     * @When(I)hover :element
+     * @When (I )hover :element
      */
     public function iHoverIShouldSeeIn($element): void
     {
@@ -137,7 +137,7 @@ class BrowserContext extends BaseContext
     /**
      * Save value of the field in parameters array.
      *
-     * @When(I)save the value of :field in the :parameter parameter
+     * @When (I )save the value of :field in the :parameter parameter
      */
     public function iSaveTheValueOfInTheParameter($field, $parameter): void
     {
@@ -153,7 +153,7 @@ class BrowserContext extends BaseContext
     /**
      * Checks, that the page should contains specified text after given timeout.
      *
-     * @Then(I)wait :count second(s) until I see :text
+     * @Then (I )wait :count second(s) until I see :text
      */
     public function iWaitSecondsUntilISee($count, $text): void
     {
@@ -163,7 +163,7 @@ class BrowserContext extends BaseContext
     /**
      * Checks, that the page should not contain specified text before given timeout.
      *
-     * @Then(I)should not see :text within :count second(s)
+     * @Then (I )should not see :text within :count second(s)
      */
     public function iDontSeeInSeconds($count, $text): void
     {
@@ -180,7 +180,7 @@ class BrowserContext extends BaseContext
     /**
      * Checks, that the page should contains specified text after timeout.
      *
-     * @Then(I)wait until I see :text
+     * @Then (I )wait until I see :text
      */
     public function iWaitUntilISee($text): void
     {
@@ -190,7 +190,7 @@ class BrowserContext extends BaseContext
     /**
      * Checks, that the element contains specified text after timeout.
      *
-     * @Then(I)wait :count second(s) until I see :text in the :element element
+     * @Then (I )wait :count second(s) until I see :text in the :element element
      */
     public function iWaitSecondsUntilISeeInTheElement($count, $text, $element): void
     {
@@ -221,7 +221,7 @@ class BrowserContext extends BaseContext
     }
 
     /**
-     * @Then(I)wait :count second(s)
+     * @Then (I )wait :count second(s)
      */
     public function iWaitSeconds($count): void
     {
@@ -231,7 +231,7 @@ class BrowserContext extends BaseContext
     /**
      * Checks, that the element contains specified text after timeout.
      *
-     * @Then(I)wait until I see :text in the :element element
+     * @Then (I )wait until I see :text in the :element element
      */
     public function iWaitUntilISeeInTheElement($text, $element): void
     {
@@ -241,7 +241,7 @@ class BrowserContext extends BaseContext
     /**
      * Checks, that the page should contains specified element after timeout.
      *
-     * @Then(I)wait for :element element
+     * @Then (I )wait for :element element
      */
     public function iWaitForElement($element): void
     {
@@ -251,7 +251,7 @@ class BrowserContext extends BaseContext
     /**
      * Wait for a element.
      *
-     * @Then(I)wait :count second(s) for :element element
+     * @Then (I )wait :count second(s) for :element element
      */
     public function iWaitSecondsForElement($count, $element): void
     {
@@ -288,7 +288,7 @@ class BrowserContext extends BaseContext
     }
 
     /**
-     * @Then(I)should see less than :count :element in the :index :parent
+     * @Then (I )should see less than :count :element in the :index :parent
      */
     public function iShouldSeeLessThanNElementInTheNthParent($count, $element, $index, $parent): void
     {
@@ -299,7 +299,7 @@ class BrowserContext extends BaseContext
     }
 
     /**
-     * @Then(I)should see more than :count :element in the :index :parent
+     * @Then (I )should see more than :count :element in the :index :parent
      */
     public function iShouldSeeMoreThanNElementInTheNthParent($count, $element, $index, $parent): void
     {
@@ -403,8 +403,8 @@ class BrowserContext extends BaseContext
     /**
      * Select a frame by its name or ID.
      *
-     * @When(I)switch to iframe :name
-     * @When(I)switch to frame :name
+     * @When (I )switch to iframe :name
+     * @When (I )switch to frame :name
      */
     public function switchToIFrame($name): void
     {
@@ -414,7 +414,7 @@ class BrowserContext extends BaseContext
     /**
      * Go back to main document frame.
      *
-     * @When(I)switch to main frame
+     * @When (I )switch to main frame
      */
     public function switchToMainFrame(): void
     {

--- a/src/Context/BrowserContext.php
+++ b/src/Context/BrowserContext.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Context;
 
 use Behat\Behat\Tester\Exception\PendingException;

--- a/src/Context/ContextClass/ClassResolver.php
+++ b/src/Context/ContextClass/ClassResolver.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Context\ContextClass;
 
 use Behat\Behat\Context\ContextClass\ClassResolver as BaseClassResolver;

--- a/src/Context/DebugContext.php
+++ b/src/Context/DebugContext.php
@@ -23,7 +23,7 @@ class DebugContext extends BaseContext
     /**
      * Pauses the scenario until the user presses a key. Useful when debugging a scenario.
      *
-     * @Then(I)put a breakpoint
+     * @Then (I )put a breakpoint
      */
     public function iPutABreakpoint(): void
     {

--- a/src/Context/DebugContext.php
+++ b/src/Context/DebugContext.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Context;
 
 use Behat\Behat\Hook\Scope\AfterStepScope;

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Context;
 
 use Behat\Gherkin\Node\PyStringNode;

--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Context;
 
 use Behat\Gherkin\Node\PyStringNode;

--- a/src/Context/SystemContext.php
+++ b/src/Context/SystemContext.php
@@ -28,7 +28,7 @@ class SystemContext implements Context
     /**
      * Execute a command.
      *
-     * @Given(I)execute :command
+     * @Given (I )execute :command
      */
     public function iExecute($cmd): void
     {
@@ -42,7 +42,7 @@ class SystemContext implements Context
     /**
      * Execute a command from project root.
      *
-     * @Given(I)execute :command from project root
+     * @Given (I )execute :command from project root
      */
     public function iExecuteFromProjectRoot($cmd): void
     {
@@ -53,7 +53,7 @@ class SystemContext implements Context
     /**
      * Display the last command output.
      *
-     * @Then(I)display the last command output
+     * @Then (I )display the last command output
      */
     public function iDumpCommandOutput(): void
     {
@@ -180,8 +180,8 @@ class SystemContext implements Context
     }
 
     /**
-     * @Given(I)create the file :filename containing:
-     * @Given(I)create the file :filename contening:
+     * @Given (I )create the file :filename containing:
+     * @Given (I )create the file :filename contening:
      */
     public function iCreateTheFileContaining($filename, PyStringNode $string): void
     {

--- a/src/Context/SystemContext.php
+++ b/src/Context/SystemContext.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Context;
 
 use Behat\Behat\Context\Context;

--- a/src/Context/TableContext.php
+++ b/src/Context/TableContext.php
@@ -28,7 +28,7 @@ class TableContext extends BaseContext
     /**
      * Checks that the specified table contains the given number of columns.
      *
-     * @Then(I)should see :count column(s) in the :table table
+     * @Then (I )should see :count column(s) in the :table table
      */
     public function iShouldSeeColumnsInTheTable($count, $table): void
     {
@@ -41,7 +41,7 @@ class TableContext extends BaseContext
     /**
      * Checks that the specified table contains the specified number of rows in its body.
      *
-     * @Then(I)should see :count rows in the :index :table table
+     * @Then (I )should see :count rows in the :index :table table
      */
     public function iShouldSeeRowsInTheNthTable($count, $index, $table): void
     {
@@ -52,7 +52,7 @@ class TableContext extends BaseContext
     /**
      * Checks that the specified table contains the specified number of rows in its body.
      *
-     * @Then(I)should see :count row(s) in the :table table
+     * @Then (I )should see :count row(s) in the :table table
      */
     public function iShouldSeeRowsInTheTable($count, $table): void
     {

--- a/src/Context/TableContext.php
+++ b/src/Context/TableContext.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Context;
 
 use Behat\Gherkin\Node\TableNode;

--- a/src/Context/XmlContext.php
+++ b/src/Context/XmlContext.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Context;
 
 use Behat\Gherkin\Node\PyStringNode;

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch;
 
 use Behat\Behat\Context\ServiceContainer\ContextExtension;

--- a/src/Html.php
+++ b/src/Html.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch;
 
 trait Html

--- a/src/HttpCall/ContextSupportedVoter.php
+++ b/src/HttpCall/ContextSupportedVoter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall;
 
 interface ContextSupportedVoter

--- a/src/HttpCall/ContextSupportedVoters.php
+++ b/src/HttpCall/ContextSupportedVoters.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall;
 
 class ContextSupportedVoters implements ContextSupportedVoter

--- a/src/HttpCall/FilterableHttpCallResult.php
+++ b/src/HttpCall/FilterableHttpCallResult.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall;
 
 interface FilterableHttpCallResult

--- a/src/HttpCall/HttpCallListener.php
+++ b/src/HttpCall/HttpCallListener.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall;
 
 use Behat\Behat\EventDispatcher\Event\AfterStepTested;

--- a/src/HttpCall/HttpCallResult.php
+++ b/src/HttpCall/HttpCallResult.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall;
 
 class HttpCallResult

--- a/src/HttpCall/HttpCallResultPool.php
+++ b/src/HttpCall/HttpCallResultPool.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall;
 
 class HttpCallResultPool

--- a/src/HttpCall/HttpCallResultPoolResolver.php
+++ b/src/HttpCall/HttpCallResultPoolResolver.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall;
 
 use Behat\Behat\Context\Argument\ArgumentResolver;

--- a/src/HttpCall/Request.php
+++ b/src/HttpCall/Request.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall;
 
 use Behat\Mink\Mink;

--- a/src/HttpCall/Request/BrowserKit.php
+++ b/src/HttpCall/Request/BrowserKit.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall\Request;
 
 use Behat\Mink\Driver\Goutte\Client as GoutteClient;

--- a/src/HttpCall/Request/Goutte.php
+++ b/src/HttpCall/Request/Goutte.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall\Request;
 
 class Goutte extends BrowserKit

--- a/src/HttpCall/RestContextVoter.php
+++ b/src/HttpCall/RestContextVoter.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\HttpCall;
 
 class RestContextVoter implements ContextSupportedVoter, FilterableHttpCallResult

--- a/src/Json/Json.php
+++ b/src/Json/Json.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Json;
 
 use Symfony\Component\PropertyAccess\PropertyAccessor;

--- a/src/Json/JsonInspector.php
+++ b/src/Json/JsonInspector.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Json;
 
 use Symfony\Component\PropertyAccess\PropertyAccessor;

--- a/src/Json/JsonSchema.php
+++ b/src/Json/JsonSchema.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Json;
 
 use JsonSchema\SchemaStorage;

--- a/src/Xml/Dom.php
+++ b/src/Xml/Dom.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Xml;
 
 class Dom

--- a/tests/features/bootstrap/Bootstrap.php
+++ b/tests/features/bootstrap/Bootstrap.php
@@ -1,5 +1,3 @@
 <?php
 
-declare(strict_types=1);
-
 require_once __DIR__.'/../../../vendor/autoload.php';

--- a/tests/fixtures/www/browser/auth.php
+++ b/tests/fixtures/www/browser/auth.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 session_start();
 
 $username = 'gabriel';

--- a/tests/fixtures/www/rest/index.php
+++ b/tests/fixtures/www/rest/index.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 error_reporting(\E_ALL);
 

--- a/tests/units/Context/JsonContext.php
+++ b/tests/units/Context/JsonContext.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Tests\Units\Context;
 
 use Behat\Gherkin\Node\TableNode;

--- a/tests/units/Json/Json.php
+++ b/tests/units/Json/Json.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Tests\Units\Json;
 
 use Symfony\Component\PropertyAccess\PropertyAccess;

--- a/tests/units/Json/JsonInspector.php
+++ b/tests/units/Json/JsonInspector.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Tests\Units\Json;
 
 class JsonInspector extends \atoum

--- a/tests/units/Json/JsonSchema.php
+++ b/tests/units/Json/JsonSchema.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Behatch\Tests\Units\Json;
 
 class JsonSchema extends \atoum


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main (didn't find current `3.x` branch)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | 

The commit [php-cs-fixer](https://github.com/soyuka/contexts/commit/2035fc46a5adfb262e30cbfa8e4461a9a72b044b) broke some steps definition in a few contexts.
The rule `doctrine_annotation_spaces` remove spaces around parentheses for Doctrine annotations but it works with a blacklist which is not including `Given`, `When` and `Then`.

It also introduced the `declare(strict_types=1);` which generates error in multiple places.  
For instance in the `DebugContext` there is:
```php
$featureName = urlencode(str_replace(' ', '_', $scope->getFeature()->getTitle()));
```
But `getTitle` returns `string|null` because the title is optional, which generates `TypeError` exceptions hiding the real failure of the test.
In `Asserter::assertContains()` we use `preg_quote` to perform the check but the expected value could be something else than a string and tests fails even though they were passing before.