### PR TITLE
fix(json): Call to a member function getValue() on null in JsonContex…

### DIFF
--- a/src/HttpCall/HttpCallListener.php
+++ b/src/HttpCall/HttpCallListener.php
@@ -58,6 +58,8 @@ class HttpCallListener implements EventSubscriberInterface
             // Mink has no response
         } catch (\Behat\Mink\Exception\DriverException $e) {
             // No Mink
+        } catch (\WebDriver\Exception\NoSuchDriver $e) {
+            // A session is either terminated or not started
         }
     }
 }

--- a/src/HttpCall/HttpCallListener.php
+++ b/src/HttpCall/HttpCallListener.php
@@ -48,11 +48,6 @@ class HttpCallListener implements EventSubscriberInterface
             return true;
         }
 
-        // Session can be stopped. Ex: using SystemContext
-        if (!$this->mink->getSession()->isStarted()) {
-            return;
-        }
-
         // For now to avoid modification on MinkContext
         // We add fallback on Mink
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes<!-- please update CHANGELOG.md file -->
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? |no
| Tickets       | 
| License       | MIT
| Doc PR        | 

fix(json): Call to a member function getValue() on null in JsonContext:getJson

See here : https://github.com/soyuka/contexts/commit/8215019f4f75d3e184f70b075e5a352b6551f0bc#r109969509

Ping @Jean-Beru  @develth @NicoHaase