### PR TITLE
fix: context voter now receives a string and not a DocumentElement

### DIFF
--- a/src/HttpCall/RestContextVoter.php
+++ b/src/HttpCall/RestContextVoter.php
@@ -6,11 +6,11 @@ class RestContextVoter implements ContextSupportedVoter, FilterableHttpCallResul
 {
     public function vote(HttpCallResult $httpCallResult)
     {
-        return $httpCallResult->getValue() instanceof \Behat\Mink\Element\DocumentElement;
+        return $httpCallResult->getValue() instanceof \Behat\Mink\Element\DocumentElement || is_string($httpCallResult->getValue());
     }
 
     public function filter(HttpCallResult $httpCallResult)
     {
-        return $httpCallResult->getValue()->getContent();
+        return is_string($httpCallResult->getValue()) ? $httpCallResult->getValue() : $httpCallResult->getValue()->getContent();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A
