### PR TITLE
Explicit message for "json node should have :nb elements"

### DIFF
--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -207,7 +207,13 @@ class JsonContext extends BaseContext
 
         $actual = $this->inspector->evaluate($json, $node);
 
-        $this->assertSame($count, \count((array) $actual));
+        $actualCount = \count((array) $actual);
+
+        $this->assertSame(
+            $count,
+            $actualCount,
+            'The node "'.$node.'" contains '.$actualCount.' elements ('.$count.' expected).'
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Make the output of `@Then the JSON node :node should have :count element(s)` more explicit

Here the diff of the before / after output:


```diff
 - The element '2' is not equal to '1'
 + The JSON node "some.node" contains 2 elements (1 expected).
```