### PR TITLE
Better messages for "JSON node should (not) contain"

### DIFF
--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -226,7 +226,13 @@ class JsonContext extends BaseContext
 
         $actual = $this->inspector->evaluate($json, $node);
 
-        $this->assertContains($text, (string) $actual);
+        $printedActual = \strlen($actual) > 50 ? substr($actual, 0, 50).'[…]' : $actual;
+
+        $this->assertContains(
+            $text,
+            (string) $actual,
+            'The node "'.$node.'" does not contain the expected text "'.$text.'" (found "'.$printedActual.'")'
+        );
     }
 
     /**
@@ -252,7 +258,13 @@ class JsonContext extends BaseContext
 
         $actual = $this->inspector->evaluate($json, $node);
 
-        $this->assertNotContains($text, (string) $actual);
+        $printedActual = \strlen($actual) > 50 ? substr($actual, 0, 50).'[…]' : $actual;
+
+        $this->assertNotContains(
+            $text,
+            (string) $actual,
+            'The node "'.$node.'" does contain "'.$text.'" while it should not (found "'.$printedActual.'")'
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yno <!-- please update CHANGELOG.md file -->
| New feature?  | yno <!-- please update CHANGELOG.md file -->
| Deprecations? | yno
| Tickets       | See https://github.com/soyuka/contexts/pull/31
| License       | MIT
| Doc PR        | 


See https://github.com/soyuka/contexts/pull/31

Added better message for `theJsonNodeShouldContain` :

```
  And the JSON node "hydra:description" should contain "coucou"                                      # Behatch\Context\JsonContext::theJsonNodeShouldContain()
-       The string 'coucou' was not found. (Behat\Mink\Exception\ExpectationException)
+       The node "hydra:description" does not contain the expected text "coucou" (found "This value should be equal to 1.") (Behat\Mink\Exception\ExpectationException)
# if actual value is more that 50 char
+       The node "hydra:description" does not contain the expected text "coucou" (found "Lorem ipsum dolor sit amet, consectetur adipiscing[…]") (Behat\Mink\Exception\ExpectationException) 
```

and for `theJsonNodeShouldNotContain`

```
  And the JSON node "hydra:description" should not contain "ipsum"                                   # Behatch\Context\JsonContext::theJsonNodeShouldNotContain()
- The string 'ipsum' was found. (Behat\Mink\Exception\ExpectationException) 
+ The node "hydra:description" does contain "ipsum" while it should not (found "Lorem ipsum") (Behat\Mink\Exception\ExpectationException)   
# if actual value is more that 50 char                                         
+ The node "hydra:description" does contain "ipsum" while it should not (found "Lorem ipsum dolor sit amet, consectetur adipiscing[…]") (Behat\Mink\Exception\ExpectationException) 
```