### PR TITLE
feat: use optimized sprintf

### DIFF
--- a/src/Asserter.php
+++ b/src/Asserter.php
@@ -47,7 +47,7 @@ trait Asserter
     {
         $this->assert(
             (int) $expected === \count($elements),
-            $message ?: sprintf('%d elements found, but should be %d.', \count($elements), $expected)
+            $message ?: \sprintf('%d elements found, but should be %d.', \count($elements), $expected)
         );
     }
 

--- a/src/Context/DebugContext.php
+++ b/src/Context/DebugContext.php
@@ -63,7 +63,7 @@ class DebugContext extends BaseContext
             $scenarioName = urlencode(str_replace(' ', '_', $scenario->getTitle() ?? ''));
         }
 
-        $filename = sprintf('fail_%s_%s_%s_%s.png', time(), $suiteName, $featureName, $scenarioName);
+        $filename = \sprintf('fail_%s_%s_%s_%s.png', time(), $suiteName, $featureName, $scenarioName);
         $this->saveScreenshot($filename, $this->screenshotDir);
     }
 

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -55,7 +55,7 @@ class JsonContext extends BaseContext
         $actual = $this->inspector->evaluate($json, $node);
 
         if ($actual != $expected) {
-            throw new \Exception(sprintf("The node '%s' value is '%s', '%s' expected", $node, json_encode($actual), $expected));
+            throw new \Exception(\sprintf("The node '%s' value is '%s', '%s' expected", $node, json_encode($actual), $expected));
         }
     }
 
@@ -75,7 +75,7 @@ class JsonContext extends BaseContext
             $expected = self::reespaceSpecialGherkinValue($expected);
 
             if ($actual != $expected) {
-                $errors[] = sprintf("The node '%s' value is '%s', '%s' expected", $node, json_encode($actual), $expected);
+                $errors[] = \sprintf("The node '%s' value is '%s', '%s' expected", $node, json_encode($actual), $expected);
             }
         }
 
@@ -96,7 +96,7 @@ class JsonContext extends BaseContext
         $actual = $this->inspector->evaluate($json, $node);
 
         if (0 === preg_match($pattern, $actual)) {
-            throw new \Exception(sprintf("The node '%s' value is '%s', '%s' pattern expected", $node, json_encode($actual), $pattern));
+            throw new \Exception(\sprintf("The node '%s' value is '%s', '%s' pattern expected", $node, json_encode($actual), $pattern));
         }
     }
 
@@ -112,7 +112,7 @@ class JsonContext extends BaseContext
         $actual = $this->inspector->evaluate($json, $node);
 
         if (null !== $actual) {
-            throw new \Exception(sprintf("The node '%s' value is '%s', null expected", $node, json_encode($actual)));
+            throw new \Exception(\sprintf("The node '%s' value is '%s', null expected", $node, json_encode($actual)));
         }
     }
 
@@ -128,7 +128,7 @@ class JsonContext extends BaseContext
         $actual = $this->inspector->evaluate($json, $node);
 
         if (null === $actual) {
-            throw new \Exception(sprintf("The node '%s' value is null, non-null value expected", $node));
+            throw new \Exception(\sprintf("The node '%s' value is null, non-null value expected", $node));
         }
     }
 
@@ -144,7 +144,7 @@ class JsonContext extends BaseContext
         $actual = $this->inspector->evaluate($json, $node);
 
         if (true !== $actual) {
-            throw new \Exception(sprintf("The node '%s' value is '%s', 'true' expected", $node, json_encode($actual)));
+            throw new \Exception(\sprintf("The node '%s' value is '%s', 'true' expected", $node, json_encode($actual)));
         }
     }
 
@@ -160,7 +160,7 @@ class JsonContext extends BaseContext
         $actual = $this->inspector->evaluate($json, $node);
 
         if (false !== $actual) {
-            throw new \Exception(sprintf("The node '%s' value is '%s', 'false' expected", $node, json_encode($actual)));
+            throw new \Exception(\sprintf("The node '%s' value is '%s', 'false' expected", $node, json_encode($actual)));
         }
     }
 
@@ -176,7 +176,7 @@ class JsonContext extends BaseContext
         $actual = $this->inspector->evaluate($json, $node);
 
         if ($actual !== $expected) {
-            throw new \Exception(sprintf("The node '%s' value is '%s', string '%s' expected", $node, json_encode($actual), $expected));
+            throw new \Exception(\sprintf("The node '%s' value is '%s', string '%s' expected", $node, json_encode($actual), $expected));
         }
     }
 
@@ -192,7 +192,7 @@ class JsonContext extends BaseContext
         $actual = $this->inspector->evaluate($json, $node);
 
         if ($actual !== (float) $number && $actual !== (int) $number) {
-            throw new \Exception(sprintf("The node '%s' value is '%s', number '%s' expected", $node, json_encode($actual), (string) $number));
+            throw new \Exception(\sprintf("The node '%s' value is '%s', number '%s' expected", $node, json_encode($actual), (string) $number));
         }
     }
 

--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -130,7 +130,7 @@ class RestContext extends BaseContext
     public function theHeaderShouldBeContains($name, $value): void
     {
         @trigger_error(
-            sprintf('The %s function is deprecated since version 3.1 and will be removed in 4.0. Use the %s::theHeaderShouldContain function instead.', __METHOD__, __CLASS__),
+            \sprintf('The %s function is deprecated since version 3.1 and will be removed in 4.0. Use the %s::theHeaderShouldContain function instead.', __METHOD__, __CLASS__),
             \E_USER_DEPRECATED
         );
         $this->theHeaderShouldContain($name, $value);
@@ -216,7 +216,7 @@ class RestContext extends BaseContext
         $expires = new \DateTime($this->request->getHttpRawHeader('Expires')[0]);
 
         $this->assertSame(1, $expires->diff($date)->invert,
-            sprintf('The response doesn\'t expire in the future (%s)', $expires->format(\DATE_ATOM))
+            \sprintf('The response doesn\'t expire in the future (%s)', $expires->format(\DATE_ATOM))
         );
     }
 

--- a/src/Context/SystemContext.php
+++ b/src/Context/SystemContext.php
@@ -66,7 +66,7 @@ class SystemContext implements Context
     public function commandShouldSucceed(): void
     {
         if (0 !== $this->lastReturnCode) {
-            throw new \Exception(sprintf('Command should succeed %b', $this->lastReturnCode));
+            throw new \Exception(\sprintf('Command should succeed %b', $this->lastReturnCode));
         }
     }
 
@@ -78,7 +78,7 @@ class SystemContext implements Context
     public function commandShouldFail(): void
     {
         if (0 === $this->lastReturnCode) {
-            throw new \Exception(sprintf('Command should fail %b', $this->lastReturnCode));
+            throw new \Exception(\sprintf('Command should fail %b', $this->lastReturnCode));
         }
     }
 
@@ -90,7 +90,7 @@ class SystemContext implements Context
     public function commandShouldLastLessThan($seconds): void
     {
         if ($this->lastExecutionTime > $seconds) {
-            throw new \Exception(sprintf('Last command last %s which is more than %s seconds', $this->lastExecutionTime, $seconds));
+            throw new \Exception(\sprintf('Last command last %s which is more than %s seconds', $this->lastExecutionTime, $seconds));
         }
     }
 
@@ -102,7 +102,7 @@ class SystemContext implements Context
     public function commandShouldMoreLessThan($seconds): void
     {
         if ($this->lastExecutionTime < $seconds) {
-            throw new \Exception(sprintf('Last command last %s which is less than %s seconds', $this->lastExecutionTime, $seconds));
+            throw new \Exception(\sprintf('Last command last %s which is less than %s seconds', $this->lastExecutionTime, $seconds));
         }
     }
 
@@ -124,7 +124,7 @@ class SystemContext implements Context
         }
 
         if (false === $check) {
-            throw new \Exception(sprintf("The text '%s' was not found anywhere on output of command.\n%s", $text, implode("\n", $this->output)));
+            throw new \Exception(\sprintf("The text '%s' was not found anywhere on output of command.\n%s", $text, implode("\n", $this->output)));
         }
     }
 
@@ -139,7 +139,7 @@ class SystemContext implements Context
 
         foreach ($this->output as $line) {
             if (1 === preg_match($regex, $line)) {
-                throw new \Exception(sprintf("The text '%s' was found somewhere on output of command.\n%s", $text, implode("\n", $this->output)));
+                throw new \Exception(\sprintf("The text '%s' was found somewhere on output of command.\n%s", $text, implode("\n", $this->output)));
             }
         }
     }
@@ -152,7 +152,7 @@ class SystemContext implements Context
         $expected = $string->getStrings();
         foreach ($this->output as $index => $line) {
             if ($line !== $expected[$index]) {
-                throw new \Exception(sprintf("instead of\n%s", implode("\n", $this->output)));
+                throw new \Exception(\sprintf("instead of\n%s", implode("\n", $this->output)));
             }
         }
     }

--- a/src/Json/JsonSchema.php
+++ b/src/Json/JsonSchema.php
@@ -34,7 +34,7 @@ class JsonSchema extends Json
         if (!$validator->isValid()) {
             $msg = 'JSON does not validate. Violations:'.\PHP_EOL;
             foreach ($validator->getErrors() as $error) {
-                $msg .= sprintf('  - [%s] %s'.\PHP_EOL, $error['property'], $error['message']);
+                $msg .= \sprintf('  - [%s] %s'.\PHP_EOL, $error['property'], $error['message']);
             }
             throw new \Exception($msg);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no 
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

`sprintf` has been optimized in 8.4. This PR prefixes all calls and so, fixes the CI.

See https://tideways.com/profiler/blog/new-in-php-8-4-engine-optimization-of-sprintf-to-string-interpolation
