### PR TITLE
ci: add tests for php 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,11 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -45,12 +46,13 @@ jobs:
            - '8.1'
            - '8.2'
            - '8.3'
+           - '8.4'
        fail-fast: false
      env:
        APP_DEBUG: '1' # https://github.com/phpstan/phpstan-symfony/issues/37
      steps:
        - name: Checkout
-         uses: actions/checkout@v4
+         uses: actions/checkout@v5
        - name: Setup PHP
          uses: shivammathur/setup-php@v2
          with:
@@ -91,11 +93,12 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
       fail-fast: false
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -132,7 +135,7 @@ jobs:
     env:
       DISPLAY: ':99'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,4 +173,4 @@ jobs:
           while ! nc -z localhost 8080 </dev/null; do echo Waiting for PHP server to start...; sleep 1; done
         timeout-minutes: 1
       - name: Run behat tests
-        run: ./bin/behat -fprogress --no-interaction --profile=${{ matrix.profile }}
+        run: ./bin/behat -fprogress --no-interaction --profile=${{ matrix.profile }} --strict

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     },
 
     "require-dev": {
-        "behat/mink-goutte-driver": "^1.1",
-        "guzzlehttp/guzzle": "^6.3",
-        "behat/mink-selenium2-driver": "^1.6",
-        "atoum/atoum": "^4.0",
-        "fabpot/goutte": "^3.2",
-        "phpunit/phpunit": "^9.5",
-        "atoum/stubs": "^2.6"
+        "behat/mink-goutte-driver": "^1.3 || ^2.0",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0",
+        "behat/mink-selenium2-driver": "^1.7",
+        "atoum/atoum": "^4.4",
+        "fabpot/goutte": "^3.3 || ^4.0",
+        "phpunit/phpunit": "^9.6.29",
+        "atoum/stubs": "^2.7"
     },
 
     "autoload": {

--- a/src/Json/Json.php
+++ b/src/Json/Json.php
@@ -4,7 +4,7 @@ namespace Behatch\Json;
 
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
-class Json
+class Json implements \Stringable
 {
     protected $content;
 
@@ -45,7 +45,7 @@ class Json
         return json_encode($this->content, $flags);
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->encode(false);
     }

--- a/src/Xml/Dom.php
+++ b/src/Xml/Dom.php
@@ -2,7 +2,7 @@
 
 namespace Behatch\Xml;
 
-class Dom
+class Dom implements \Stringable
 {
     private $dom;
 
@@ -16,7 +16,7 @@ class Dom
         $this->throwError();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $this->dom->formatOutput = true;
 

--- a/tests/features/en/browser.feature
+++ b/tests/features/en/browser.feature
@@ -1,3 +1,4 @@
+# language: en
 Feature: Browser Feature
 
     # If this scenario fails

--- a/tests/features/en/debug.feature
+++ b/tests/features/en/debug.feature
@@ -1,3 +1,4 @@
+# language: en
 Feature: Browser Feature
 
     @user

--- a/tests/features/en/json.feature
+++ b/tests/features/en/json.feature
@@ -1,3 +1,4 @@
+# language: en
 @json
 Feature: Testing JSONContext
 

--- a/tests/features/en/rest.feature
+++ b/tests/features/en/rest.feature
@@ -1,3 +1,4 @@
+# language: en
 @rest
 Feature: Testing RESTContext
 
@@ -100,7 +101,7 @@ Feature: Testing RESTContext
 
     Scenario: Accept header should not be set by dfault
       When I send a GET request to "/rest/index.php"
-      Then I should not see "HTTP_ACCEPT"
+      Then I should not see "HTTP_ACCEPT :"
 
   @>php5.5
     Scenario: Set content headers in POST request

--- a/tests/features/en/system.feature
+++ b/tests/features/en/system.feature
@@ -1,3 +1,4 @@
+# language: en
 Feature: System feature
 
     Scenario: Testing execution

--- a/tests/features/en/table.feature
+++ b/tests/features/en/table.feature
@@ -1,3 +1,4 @@
+# language: en
 Feature: Browser Feature
 
     Scenario: Testing access to /table/index.html

--- a/tests/features/en/xml.feature
+++ b/tests/features/en/xml.feature
@@ -1,3 +1,4 @@
+# language: en
 @xml
 Feature: Testing XmlContext
 

--- a/tests/features/ja/browser.feature
+++ b/tests/features/ja/browser.feature
@@ -9,7 +9,7 @@
     @javascript
     シナリオ: Testing simple web access
        前提 "/index.html" を表示している
-        ならば　画面に "Congratulations, you've correctly set up your apache environment." と表示されていること
+        ならば 画面に "Congratulations, you've correctly set up your apache environment." と表示されていること
 
     @statusCode
     シナリオ: Basic authentication
@@ -65,9 +65,9 @@
         ならば 私が"timeout"を見るまで3秒間待つ
         かつ 私が1秒間待つ
         かつ 私が"#iframe"要素を見るまで待つ
-        かつ　私が "#iframe" 要素を見るまで 5 秒間待つ
-        かつ　私が "#iframe" 要素を見るまで 5 秒待つ
-        かつ　"#iframe" 要素を見るまで 5 秒待つ
+        かつ 私が "#iframe" 要素を見るまで 5 秒間待つ
+        かつ 私が "#iframe" 要素を見るまで 5 秒待つ
+        かつ "#iframe" 要素を見るまで 5 秒待つ
 
     @javascript
     シナリオ: Check element visibility


### PR DESCRIPTION
bump min versions

`"fabpot/goutte": "^3.3 || ^4.0", ` allows max symfony/dom-crawler from 5 => 6

Next steps (seperate PR): support PHP 8.5 and Symfony 8

CI is failing. i have to take a deeper look
