### PR TITLE
ci: fix PhpStan

### DIFF
--- a/src/Context/RestContext.php
+++ b/src/Context/RestContext.php
@@ -50,7 +50,7 @@ class RestContext extends BaseContext
                 throw new \Exception("You must provide a 'key' and 'value' column in your table node.");
             }
 
-            if (\is_string($row['value']) && '@' == substr($row['value'], 0, 1)) {
+            if (str_starts_with($row['value'], '@')) {
                 $files[$row['key']] = rtrim($this->getMinkParameter('files_path'), \DIRECTORY_SEPARATOR).\DIRECTORY_SEPARATOR.substr($row['value'], 1);
             } else {
                 $parameters[$row['key']] = $row['value'];

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -20,9 +20,6 @@ class Extension implements ExtensionInterface
 
     public function initialize(ExtensionManager $extensionManager): void
     {
-        if (\PHP_MAJOR_VERSION === 5) {
-            @trigger_error('The behatch context extension will drop support for PHP 5 in version 4.0', \E_USER_DEPRECATED);
-        }
     }
 
     public function process(ContainerBuilder $container): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Fix PHPStan tests:
- Trust PhpStan annotation in `RestContext` (`$row` value is always a string
- No need to check PHP5 since minimum requirement is now >=8 in `Extension`